### PR TITLE
Add links to past conf pages to footer

### DIFF
--- a/data/footer.yml
+++ b/data/footer.yml
@@ -12,3 +12,8 @@ content:
       - nameKey: footer_coc
         url: https://golang.org/conduct
         newTab: true
+  - title: footer_past_confs
+    links:
+      - name: 2021 Spring
+        url: https://gocon.jp/2021spring
+        newTab: true

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -64,6 +64,8 @@ other = "Partnership Proposition"
 [footer_coc]
 other = "Code of Conduct"
 
+[footer_past_confs]
+other = "Past Conferences"
 
 ################
 # Subscription #

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -67,6 +67,9 @@ other = "スポンサーのお申込み"
 [footer_coc]
 other = "行動指針"
 
+[footer_past_confs]
+other = "Past Conferences"
+
 ################
 # Subscription #
 ################


### PR DESCRIPTION
フッターに2021 Springのカンファレンスページへのリンクを追加します。

![image](https://user-images.githubusercontent.com/2227862/129762315-731dfc4d-0094-4949-a4ec-6f82a75db931.png)