### PR TITLE
パートナー一覧ページをdraft状態で復活させる

### DIFF
--- a/content/partners/_index.ja.md
+++ b/content/partners/_index.ja.md
@@ -12,7 +12,7 @@ draft: false
 
 {{% /hero %}}
 
-<!-- Parteners list -->
+<!-- Partners list -->
 
 {{% partners categories="gold,silver,bronze,green" %}}
 

--- a/content/partners/_index.ja.md
+++ b/content/partners/_index.ja.md
@@ -4,7 +4,7 @@ menu:
   main:
     weight: 20
 
-draft: false
+draft: true
 ---
 
 {{% hero %}}

--- a/content/partners/_index.ja.md
+++ b/content/partners/_index.ja.md
@@ -1,0 +1,19 @@
+---
+title: スポンサー
+menu:
+  main:
+    weight: 20
+
+draft: false
+---
+
+{{% hero %}}
+
+
+{{% /hero %}}
+
+<!-- Parteners list -->
+
+{{% partners categories="gold,silver,bronze,green" %}}
+
+{{% /partners %}}

--- a/content/partners/_index.md
+++ b/content/partners/_index.md
@@ -12,7 +12,7 @@ draft: false
 
 {{% /hero %}}
 
-<!-- Parteners list -->
+<!-- Partners list -->
 
 {{% partners categories="gold,silver,bronze,green" %}}
 

--- a/content/partners/_index.md
+++ b/content/partners/_index.md
@@ -4,7 +4,7 @@ menu:
   main:
     weight: 20
 
-draft: false
+draft: true
 ---
 
 {{% hero %}}

--- a/content/partners/_index.md
+++ b/content/partners/_index.md
@@ -1,0 +1,19 @@
+---
+title: Partners
+menu:
+  main:
+    weight: 20
+
+draft: false
+---
+
+{{% hero %}}
+
+
+{{% /hero %}}
+
+<!-- Parteners list -->
+
+{{% partners categories="gold,silver,bronze,green" %}}
+
+{{% /partners %}}


### PR DESCRIPTION
一旦削除していたパートナー一覧ページ(`/partners`)のファイルをdraft状態で復活させます。（そもそもファイルごと削除せずにdraft状態にしておけばよかった）

「パートナーが空かどうかによってページの表示状態が自動的に切り替わる」という挙動にしたかったのですが、シンプルな実装ができそうになかったのでひとまずこれで。