### PR TITLE
トップページから「スポンサー」の見出しを隠す

### DIFF
--- a/content/_index.ja.md
+++ b/content/_index.ja.md
@@ -65,10 +65,12 @@ icon="right" %}}
 {{% /home-tickets %}}
 
 
+<!--
 {{% partners categories="gold,silver,bronze,green" %}}
 # スポンサー
 
 {{% /partners %}}
+-->
 
 <div class="plain-notice">
   <p>

--- a/content/_index.md
+++ b/content/_index.md
@@ -62,9 +62,11 @@ icon="right" %}}
 
 {{% /home-tickets %}}
 
+<!--
 {{% partners categories="gold,silver,bronze,green" %}}
 # Partners
 {{% /partners %}}
+-->
 
 <div class="plain-notice">
   <p>


### PR DESCRIPTION
スポンサーが空でも見出しだけは常に表示されるようになってしまっていた。

This reverts commit ec5e2a4d26a1fa218b883ebf24d1d5e3a8996744.