### PR TITLE
Improve support website param in layout/partners/single.html

### DIFF
--- a/layouts/partners/single.html
+++ b/layouts/partners/single.html
@@ -1,10 +1,26 @@
 {{ define "main" }}
 
 <section class="header">
-	<div class="card" style="background-image: url({{ .Site.BaseURL }}{{ .Params.logo }});"></div>
-	<h1>{{ .Title }}</h1>
+	<div class="card">
+		{{ if .Params.website }}
+		<a href="{{ .Params.website }}">
+			<img src="{{ .Site.BaseURL }}{{ .Params.logo }}">
+		</a>
+		{{ else }}
+			<img src="{{ .Site.BaseURL }}{{ .Params.logo }}">
+		{{ end }}
+	</div>
 	{{ if .Params.website }}
-	<a href="{{ .Params.website }}">{{ .Params.website }}</a>
+	<h1>
+		<a href="{{ .Params.website }}">
+			{{ .Title }}
+		</a>
+	</h1>
+	<h2>
+		<a href="{{ .Params.website }}">{{ .Params.website }}</a>
+	</h2>
+	{{ else }}
+		<h1>{{ .Title }}</h1>
 	{{ end }}
 </section>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -16,6 +16,12 @@
   text-transform: none;
 }
 
+.partners .header .card img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
 .talk .complexity:before {
     content: "Level : ";
 }


### PR DESCRIPTION
- `website`パラメータを渡したときにリンクの要素がロゴの上に出現してしまう不具合を修正
- ロゴとパートナー名もリンクにするように修正