### PR TITLE
Replace deprecated Page.Hugo with global hugo function

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
 	{{ template "_internal/google_analytics_async.html" . }}
 	{{ end }}
 
-	{{ .Hugo.Generator }}
+	{{ hugo.Generator }}
 	<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 	<title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>


### PR DESCRIPTION
ビルド時に以下の警告が出ていた。

```
  $ hugo server
  Start building sites …
  hugo v0.85.0-DEV+extended linux/amd64 BuildDate=unknown
  Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.
  ...
```

devfest-themeでも同様に修正されている。
GDGToulouse/devfest-theme-hugo@3032529