### PR TITLE
Enable hardwrap in markdown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,4 +50,5 @@ googleAnalytics = "UA-127197700-1"
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
+      hardWraps = true
       unsafe = true


### PR DESCRIPTION
markdownのテキスト内の改行を<br>タグとしてレンダリングするオプションを有効にします。

gocon.jpでは提出されたテキストを流し込むことが多いですが、

* hardwrapしたほうがよさそうなテキストがいくつかある
* hardwrapしないほうがよさそうなテキストはない

という状況なので、有効にしたほうがメリットが大きそうです。