### PR TITLE
本編チケットの取得可能期間を表示しない

### DIFF
--- a/content/_index.ja.md
+++ b/content/_index.ja.md
@@ -55,8 +55,6 @@ icon="right" %}}
 
 <ul>
 <li>{{<ticket name="セッション"
-           starts="2021-10-01"
-           ends="2021-11-23"
            price="無料"
            url="https://gocon.connpass.com/event/213865/">}}</li>
 </li>

--- a/content/_index.md
+++ b/content/_index.md
@@ -53,8 +53,6 @@ icon="right" %}}
 
 <ul>
 <li>{{<ticket name="Sessions"
-           starts="2021-10-01"
-           ends="2021-11-23"
            price="Free"
            url="https://gocon.connpass.com/event/213865/">}}
 </li>


### PR DESCRIPTION
#55 で省略可能にした。開催日まで取得可能なので、わざわざ期間を明記する必要はない。