### PR TITLE
言語選択ラベルのベースラインがメニューとずれるのを防ぐ

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -261,3 +261,10 @@ a:visited {
 .partners .inner {
   text-align: center;
 }
+
+/* themes/devfest-theme-hugo/layouts/partials/header.html */
+body > header nav .languages a.lang {
+  /* 言語選択ラベルのベースラインがメニューとずれるのを防ぐ */
+  height: auto;
+  white-space: nowrap;
+}


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/2227862/135723091-166cb7d9-7635-47ab-84df-0802deb43169.png)

**After**
![image](https://user-images.githubusercontent.com/2227862/135723080-32939342-b1c8-4998-841c-df083b5e315f.png)

`JA`の位置がやや下にずれているのを修正します。