### PR TITLE
data/formats.ymlのkeyをsnake_caseに統一する

### DIFF
--- a/data/formats.yml
+++ b/data/formats.yml
@@ -10,7 +10,7 @@
 - key: registration
   name: 'Registration'
   id: registration
-- key: Sponsor Session
+- key: sponsor_session
   name: 'Sponsor Session'
   id: sponsor_session
 - key: handson


### PR DESCRIPTION
`content/sessions/*.md`の`talkType`で参照される値です。定義されていないkeyを使うとセッションの個別ページで"Type:"の内容が空になります。

これまではスポンサーセッションの個別ページへのリンクがなかったので問題が起きなかったようです。