### PR TITLE
セッションの概要の下のボーダーを削除

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -273,3 +273,8 @@ body > header nav .languages a.lang {
 .page.speakers .hero header.no-img {
   padding-right: 0;
 }
+
+/* layouts/sessions/single.html */
+.page.sessions .talk .detail {
+  border-bottom: none;
+}


### PR DESCRIPTION
概要の上にもボーダーがあるため、概要文が空だとボーダーが二重に表示されて違和感があった。