### PR TITLE
PRごとにプレビュー環境を作る

### DIFF
--- a/.github/actions/get_preview_repo_name/action.yml
+++ b/.github/actions/get_preview_repo_name/action.yml
@@ -1,0 +1,33 @@
+name: Preview Repository Name
+description: Get preview repository name
+runs:
+  using: composite
+  steps:
+    - name: Set repository owner name
+      id: owner
+      run: echo "::set-output name=result::GoConPreview"
+      shell: bash
+
+    - name: Set repository name
+      uses: actions/github-script@v5
+      id: repo
+      with:
+        script: |
+          function sanitize(str) {
+            return str.toString().replace(/[^\w-]/g, "");
+          }
+          const repoName = context.repo.repo;
+          const prNumber = context.payload.number;
+          const branchName = context.payload.pull_request.head.ref;
+          return `${sanitize(repoName)}-pr-${sanitize(prNumber)}-${sanitize(branchName)}`;
+        result-encoding: string
+outputs:
+  owner:
+    description: Repository owner name
+    value: ${{ steps.owner.outputs.result }}
+  name:
+    description: Repository name
+    value: ${{ steps.repo.outputs.result }}
+  full_name:
+    description: Repository full name ($owner/$name)
+    value: ${{ steps.owner.outputs.result }}/${{ steps.repo.outputs.result }}

--- a/.github/actions/install_hugo/action.yml
+++ b/.github/actions/install_hugo/action.yml
@@ -1,0 +1,8 @@
+name: Install Hugo
+description: Install Hugo
+runs:
+  using: composite
+  steps:
+    - uses: peaceiris/actions-hugo@v2
+      with:
+        extended: true

--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -1,0 +1,30 @@
+name: Delete preview repository
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get preview repo name
+        uses: ./.github/actions/get_preview_repo_name
+        id: preview_repo
+
+      - name: Get GitHub token
+        id: get_token
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.PREVIEW_APP_ID }}
+          private_key: ${{ secrets.PREVIEW_APP_PRIVATE_KEY }}
+
+      - name: Delete preview repo
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/{repo_name}
+          repo_name: ${{ steps.preview_repo.outputs.full_name }}
+        env:
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,66 @@
+name: Deploy PR to preview repository
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Get preview repo name
+        uses: ./.github/actions/get_preview_repo_name
+        id: preview_repo
+
+      - name: Install Hugo
+        uses: ./.github/actions/install_hugo
+
+      - name: Build pages
+        run: hugo -v --baseURL="$baseURL"
+        env:
+          baseURL: https://${{ steps.preview_repo.outputs.owner }}.github.io/${{ steps.preview_repo.outputs.name }}
+
+      - name: Get GitHub token
+        id: get_token
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.PREVIEW_APP_ID }}
+          private_key: ${{ secrets.PREVIEW_APP_PRIVATE_KEY }}
+
+      - name: Check if new repository is needed
+        id: new_repo
+        # 新しいリポジトリを作る必要があれば'true'、なければ'false'をresultに出力する
+        run: echo "::set-output name=result::$new_repo"
+        env:
+          new_repo: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
+
+      - name: Create preview repo
+        if: steps.new_repo.outputs.result == 'true'
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /orgs/{org}/repos
+          org: ${{ steps.preview_repo.outputs.owner }}
+          name: ${{ steps.preview_repo.outputs.name }}
+        env:
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ steps.get_token.outputs.token }}
+          external_repository: ${{ steps.preview_repo.outputs.full_name }}
+          publish_dir: public
+
+      - name: Enable GitHub Pages
+        if: steps.new_repo.outputs.result == 'true'
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{repo_name}/pages
+          repo_name: ${{ steps.preview_repo.outputs.full_name }}
+          data: '{"source":{"branch":"gh-pages"}}'
+        env:
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,7 +1,8 @@
-name: GitHub Pages
+name: Deploy main branch
 
 on:
   push:
+    branches: [main]
 
 jobs:
   build-deploy:
@@ -14,12 +15,10 @@ jobs:
           # NOTE: .GitInfo や .Lastmod を使う場合には以下のオプションを有効にすること
           # fetch-depth: 0
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
-        with:
-          extended: true
+      - name: Install Hugo
+        uses: ./.github/actions/install_hugo
 
-      - name: Build
+      - name: Build pages
         run: hugo -v
 
       - name: Deploy


### PR DESCRIPTION
以下の動作をするワークフローを追加します。

**PRがopen（またはreopen）された場合**
https://github.com/GoConPreview/ にリポジトリを作成して、GitHub PagesにHugoの生成物をデプロイする。

**PRにコミットがpushされた場合**
open時に作成したリポジトリにHugoの生成物をデプロイする。

**PRがmerge（またはclose）された場合**
open時に作成したリポジトリを削除する。

### 今後やりたいこと

- Deployment APIを使ってPRからデプロイ先に飛べるようにする

---

https://medium.com/geekculture/when-youre-working-on-a-static-site-and-github-pages-feels-like-the-perfect-hosting-solution-a41c37f4e326 の実装を参考にしました。