### PR TITLE
スピーカーページの<title>にスピーカー名を含める

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,7 +19,16 @@
 	{{ hugo.Generator }}
 	<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
-	<title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
+	<title>
+		{{- block "title" . -}}
+			{{- .Site.Title -}}
+			{{ with .Params.Title }}
+				{{- " | " }}{{ . -}}
+			{{ else }}
+				{{- " | " }}{{ .Params.Name -}}
+			{{ end }}
+		{{- end -}}
+	</title>
 
 	{{ if .Site.Params.appleTouchIcon }}
 	<link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.Params.appleTouchIcon }}">


### PR DESCRIPTION
`<title>`の生成時に`.Params.Title`がなければ`.Params.Name`にフォールバックするように変更します。

### `block "title"`について

`<title>{{ block "title" . }}...`の記述はdevfest-theme-hugoに由来しています。

https://github.com/GDGToulouse/devfest-theme-hugo/blob/33db41da96c67e02b53bee49cf2a875d69efe552/layouts/partials/head.html#L23

一見すると`define "title"`でタイトルを設定できそうなのですが、`layouts/speakers/single.html`などにそのような記述を加えても無視されます。

テンプレートの呼び出しツリーは以下のようになっていて

- `baseof.html`
    - `head.html`
    - `single.html`

`single.html`と`head.html`が兄弟関係にあるせいで、`head.html`の`block`を`single.html`から上書きできないようになっているのでは？という気がしているのですが、詳細は追っていません。