### PR TITLE
プレビューリポジトリが作られる前に削除処理が走るのを避ける

### DIFF
--- a/.github/actions/get_preview_repo_name/action.yml
+++ b/.github/actions/get_preview_repo_name/action.yml
@@ -31,3 +31,6 @@ outputs:
   full_name:
     description: Repository full name ($owner/$name)
     value: ${{ steps.owner.outputs.result }}/${{ steps.repo.outputs.result }}
+  gh_page_url:
+    description: GitHub Pages URL
+    value: https://${{ steps.owner.outputs.result }}.github.io/${{ steps.repo.outputs.result }}

--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -21,6 +21,12 @@ jobs:
           app_id: ${{ secrets.PREVIEW_APP_ID }}
           private_key: ${{ secrets.PREVIEW_APP_PRIVATE_KEY }}
 
+      - name: Wait for preview repo
+        run: |
+          timeout 60s bash -c 'until curl -I --fail "$REPO_URL"; do sleep 10; done'
+        env:
+          REPO_URL: ${{ steps.preview_repo.outputs.gh_pages_url }}
+
       - name: Delete preview repo
         uses: octokit/request-action@v2.x
         with:


### PR DESCRIPTION
PRを作成して即座にマージした場合、プレビューリポジトリの作成が完了する前に削除処理が実行され、エラーが起きることがあった。