### PR TITLE
RSSを削除

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,11 +50,6 @@
 	{{ end }}
 	{{ end }}
 
-	{{ if .RSSLink }}
-	<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}"/>
-	<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}"/>
-	{{ end }}
-
 	<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
 	<link rel="stylesheet" href="/theme.css" media="all">
 	<link rel="stylesheet" href="/css/custom.css" media="all">


### PR DESCRIPTION
ビルド時に以下のような警告が出ていた。

```
Page.RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}
```

gocon.jp/2021autumnにはフィードの配信に適した記事はないので削除する。