### PR TITLE
GitHub PagesのURLは末尾に/があるのが正しい

### DIFF
--- a/.github/actions/get_preview_repo_name/action.yml
+++ b/.github/actions/get_preview_repo_name/action.yml
@@ -33,4 +33,4 @@ outputs:
     value: ${{ steps.owner.outputs.result }}/${{ steps.repo.outputs.result }}
   gh_page_url:
     description: GitHub Pages URL
-    value: https://${{ steps.owner.outputs.result }}.github.io/${{ steps.repo.outputs.result }}
+    value: https://${{ steps.owner.outputs.result }}.github.io/${{ steps.repo.outputs.result }}/


### PR DESCRIPTION
:memo: 通常はステータスコード301で/ありのURLにリダイレクトされるが、HTTPヘッダーに`accept-encoding: deflate,gzip`がついていると401が返るらしい。意図しない挙動のような気がする。

<details>
<summary>
<code>curl --head --verbose 'https://goconpreview.github.io/2021autumn-pr-107-post-preview-url'</code>
</summary>

```
*   Trying 185.199.108.153:443...
* Connected to goconpreview.github.io (185.199.108.153) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=www.github.com
*  start date: May  6 00:00:00 2020 GMT
*  expire date: Apr 14 12:00:00 2022 GMT
*  subjectAltName: host "goconpreview.github.io" matched cert's "*.github.io"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x5576cedc3aa0)
> HEAD /2021autumn-pr-107-post-preview-url HTTP/2
> Host: goconpreview.github.io
> user-agent: curl/7.79.1
> accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 301 
HTTP/2 301 
< server: GitHub.com
server: GitHub.com
< content-type: text/html
content-type: text/html
< permissions-policy: interest-cohort=()
permissions-policy: interest-cohort=()
< location: https://goconpreview.github.io/2021autumn-pr-107-post-preview-url/
location: https://goconpreview.github.io/2021autumn-pr-107-post-preview-url/
< x-github-request-id: EF1A:56C9:1D1D9:20A05:618E76E8
x-github-request-id: EF1A:56C9:1D1D9:20A05:618E76E8
< accept-ranges: bytes
accept-ranges: bytes
< date: Fri, 12 Nov 2021 14:29:49 GMT
date: Fri, 12 Nov 2021 14:29:49 GMT
< via: 1.1 varnish
via: 1.1 varnish
< age: 885
age: 885
< x-served-by: cache-itm18834-ITM
x-served-by: cache-itm18834-ITM
< x-cache: HIT
x-cache: HIT
< x-cache-hits: 2
x-cache-hits: 2
< x-timer: S1636727390.589592,VS0,VE0
x-timer: S1636727390.589592,VS0,VE0
< vary: Accept-Encoding
vary: Accept-Encoding
< x-fastly-request-id: 846f4ed2c734e0fb781f18068247694cdb50d658
x-fastly-request-id: 846f4ed2c734e0fb781f18068247694cdb50d658
< content-length: 162
content-length: 162

< 
* Connection #0 to host goconpreview.github.io left intact
```
</details>

<details>
<summary>
<code>curl --head --verbose 'https://goconpreview.github.io/2021autumn-pr-107-post-preview-url' --compressed</code>
</summary>

```
*   Trying 185.199.108.153:443...
* Connected to goconpreview.github.io (185.199.108.153) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=www.github.com
*  start date: May  6 00:00:00 2020 GMT
*  expire date: Apr 14 12:00:00 2022 GMT
*  subjectAltName: host "goconpreview.github.io" matched cert's "*.github.io"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55b4665f3aa0)
> HEAD /2021autumn-pr-107-post-preview-url HTTP/2
> Host: goconpreview.github.io
> user-agent: curl/7.79.1
> accept: */*
> accept-encoding: deflate, gzip
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 404 
HTTP/2 404 
< server: GitHub.com
server: GitHub.com
< content-type: text/html; charset=utf-8
content-type: text/html; charset=utf-8
< permissions-policy: interest-cohort=()
permissions-policy: interest-cohort=()
< etag: W/"5f7baea5-239b"
etag: W/"5f7baea5-239b"
< content-security-policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
content-security-policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
< content-encoding: gzip
content-encoding: gzip
< x-github-request-id: 87EE:5ABD:25CD1C:2AFC97:618E7658
x-github-request-id: 87EE:5ABD:25CD1C:2AFC97:618E7658
< accept-ranges: bytes
accept-ranges: bytes
< date: Fri, 12 Nov 2021 14:30:36 GMT
date: Fri, 12 Nov 2021 14:30:36 GMT
< via: 1.1 varnish
via: 1.1 varnish
< age: 1076
age: 1076
< x-served-by: cache-itm18844-ITM
x-served-by: cache-itm18844-ITM
< x-cache: HIT
x-cache: HIT
< x-cache-hits: 1
x-cache-hits: 1
< x-timer: S1636727437.627023,VS0,VE1
x-timer: S1636727437.627023,VS0,VE1
< vary: Accept-Encoding
vary: Accept-Encoding
< x-fastly-request-id: 957c76cd5785f0b344e0555ab464bcbe058c8973
x-fastly-request-id: 957c76cd5785f0b344e0555ab464bcbe058c8973
< content-length: 5142
content-length: 5142

< 
* Connection #0 to host goconpreview.github.io left intact
```
</details>