### PR TITLE
プレビューページを作成したらURLをPRに投稿する

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -64,3 +64,16 @@ jobs:
           data: '{"source":{"branch":"gh-pages"}}'
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+
+      - name: Post preview URL to PR
+        if: github.event.action == 'opened'
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/issues/{pr_number}/comments
+          owner: ${{ github.event.repository.owner.login }}
+          repo: ${{ github.event.repository.name }}
+          pr_number: ${{ github.event.pull_request.number }}
+          body: |
+            "😎 Browse the preview: ${{ steps.preview_repo.outputs.gh_page_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PRのコメントにプレビューページのURLを投稿するようにします。

以下の理由でDeployment APIは使わないことにしました。

- deploymentを適切にinactiveしようとすると実装が煩雑になる
- pushごとにPRにdeploymentのログが残るのが少し邪魔に思える
- [Netlify Deploy Previews](https://docs.netlify.com/site-deploys/deploy-previews/)はdeployment APIを使わず、PRコメントにURLやデプロイ状態を記載している